### PR TITLE
VignetteBuilder is a dependency

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -1,14 +1,15 @@
 
 #' DESCRIPTION fields that denote package dependencies
 #'
-#' Currently it has the following ones: Imports, Depends,
-#' Suggests, Enhances and LinkingTo. See the \emph{Writing R Extensions}
-#' manual for when to use which.
+#' Currently it has the following ones: Imports, Depends, Suggests, Enhances,
+#' LinkingTo, and VignetteBuilder. See the \emph{Writing R Extensions} manual
+#' for when to use which.
 #'
 #' @family field types
 #' @export
 
-dep_types <- c("Imports", "Depends", "Suggests", "Enhances", "LinkingTo")
+dep_types <- c("Imports", "Depends", "Suggests", "Enhances", "LinkingTo",
+               "VignetteBuilder")
 
 standard_fields <- c(
   "Additional_repositories",

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -6,9 +6,9 @@ test_that("get_deps", {
 
   res <- data.frame(
     stringsAsFactors = FALSE,
-    type = c("Imports", "Suggests"),
-    package = c("R6", "testthat"),
-    version = c("*", "*")
+    type = c("Imports", "Suggests", "VignetteBuilder"),
+    package = c("R6", "testthat", "knitr"),
+    version = c("*", "*", "*")
   )
 
   expect_equal(desc$get_deps(), res)
@@ -22,9 +22,9 @@ test_that("set_dep", {
 
   res <- data.frame(
     stringsAsFactors = FALSE,
-    type = c("Imports", "Imports", "Suggests"),
-    package = c("R6", "igraph", "testthat"),
-    version = c("*", "*", "*")
+    type = c("Imports", "Imports", "Suggests", "VignetteBuilder"),
+    package = c("R6", "igraph", "testthat", "knitr"),
+    version = c("*", "*", "*", "*")
   )
   expect_equal(desc$get_deps(), res)
 
@@ -32,9 +32,9 @@ test_that("set_dep", {
 
   res <- data.frame(
     stringsAsFactors = FALSE,
-    type = c("Imports", "Imports", "Suggests"),
-    package = c("R6", "igraph", "testthat"),
-    version = c("*", ">= 1.0.0", "*")
+    type = c("Imports", "Imports", "Suggests", "VignetteBuilder"),
+    package = c("R6", "igraph", "testthat", "knitr"),
+    version = c("*", ">= 1.0.0", "*", "*")
   )
 
   expect_equal(desc$get_deps(), res)
@@ -43,9 +43,9 @@ test_that("set_dep", {
 
   res <- data.frame(
     stringsAsFactors = FALSE,
-    type = c("Imports", "Imports", "Suggests", "Depends"),
-    package = c("R6", "igraph", "testthat", "igraph"),
-    version = c("*", ">= 1.0.0", "*", ">= 1.0.0")
+    type = c("Imports", "Imports", "Suggests", "VignetteBuilder", "Depends"),
+    package = c("R6", "igraph", "testthat", "knitr", "igraph"),
+    version = c("*", ">= 1.0.0", "*", "*", ">= 1.0.0")
   )
 
   expect_equal(desc$get_deps(), res)
@@ -76,9 +76,9 @@ test_that("del_dep", {
 
   res <- data.frame(
     stringsAsFactors = FALSE,
-    type = c("Imports", "Suggests"),
-    package = c("R6", "testthat"),
-    version = c("*", "*")
+    type = c("Imports", "Suggests", "VignetteBuilder"),
+    package = c("R6", "testthat", "knitr"),
+    version = c("*", "*", "*")
   )
 
   expect_equal(desc$get_deps(), res)
@@ -91,9 +91,9 @@ test_that("del_dep", {
 
   res <- data.frame(
     stringsAsFactors = FALSE,
-    type = c("Imports", "Suggests", "Depends"),
-    package = c("R6", "testthat", "igraph"),
-    version = c("*", "*", ">= 1.0.0")
+    type = c("Imports", "Suggests", "VignetteBuilder", "Depends"),
+    package = c("R6", "testthat", "knitr", "igraph"),
+    version = c("*", "*", "*", ">= 1.0.0")
   )
 
   expect_equal(desc$get_deps(), res)


### PR DESCRIPTION
Can't have "Depends" as first field because of default argument to set_dep().

Fixes #18.